### PR TITLE
Add explicit dependency on unstable-lib.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '("base" "generic-bind"))
+(define deps '("base" "generic-bind" "unstable-lib"))
 
 (define build-deps '("rackunit-lib" "scribble-lib" "racket-doc" "unstable-doc"))
 


### PR DESCRIPTION
unstable/struct is moving there as of Racket 6.2.900.10.
